### PR TITLE
bugfix/add error submodule for urllib

### DIFF
--- a/selfcookie/__main__.py
+++ b/selfcookie/__main__.py
@@ -1,11 +1,9 @@
 import typer
-
 from .package import is_available_on_pypi, is_valid_package_name
-
 
 def main(package_name: str) -> None:
     """Create a cookiecutter template for a python package"""
-
+    
     if not is_valid_package_name(package_name):
         raise typer.BadParameter(f"{package_name} is not a valid python package name")
 

--- a/selfcookie/package.py
+++ b/selfcookie/package.py
@@ -2,7 +2,7 @@ import json
 import keyword
 import re
 import urllib.request
-
+import urllib.error
 
 def is_available_on_pypi(package_name: str) -> bool:
     url = f"https://pypi.org/pypi/{package_name}/json"

--- a/tests/test_package_name.py
+++ b/tests/test_package_name.py
@@ -1,7 +1,5 @@
 import uuid
-
 from selfcookie.package import is_available_on_pypi, is_valid_package_name
-
 
 def test_is_valid_package_name():
     assert is_valid_package_name("selfcookie") is True


### PR DESCRIPTION
The error prevented proper execution of selfcookie because the `error` submodule of `urllib` was not included in the source files. Also did some whitespace formatting for better readability.